### PR TITLE
feat: flatten dom tree and other ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,9 +1011,9 @@
       }
     },
     "@nll/css": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@nll/css/-/css-9.6.0.tgz",
-      "integrity": "sha512-PGPc5fHR9qbCQfOupczIhT7CoKXCUOuWewXtS4NEcRpLPAIT+RP/peDJdktOJeWbZNWpoAAX/2pCdGKd2qAAyA=="
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@nll/css/-/css-9.7.0.tgz",
+      "integrity": "sha512-cmg1qWg978NeOPjTiwrJvo6UrGz++rwhG7GCRyVbzhVzAY30LlNsYRUx4sfK5ioHm7r88GXxKRDNLXdNawiEOw=="
     },
     "@nll/datum": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/baetheus/spellbook#readme",
   "dependencies": {
-    "@nll/css": "^9.6.0",
+    "@nll/css": "^9.7.0",
     "@nll/datum": "^3.0.3",
     "@nll/dux": "^8.1.4",
     "fp-ts": "^2.5.3",

--- a/src/components/FilterSpells/FilterSpells.tsx
+++ b/src/components/FilterSpells/FilterSpells.tsx
@@ -1,7 +1,6 @@
 import "./FilterSpells.scss";
 
 import { h } from "preact";
-import { useState, useCallback } from "preact/hooks";
 import {
   useStore,
   filtersL,
@@ -31,7 +30,7 @@ export const FiltersSpells = () => {
       <section class="filter-list">
         {Classes.map((c) => (
           <button
-            class={`pwa-3 bra-1 fld-row flg-3 ai-ctr jc-ctr ${
+            class={`vh-1 pwa-3 bra-1 fld-row flg-3 ai-ctr jc-ctr ${
               isIn(filters.class)(c) ? "ct-primary" : "ct-light"
             }`}
             title={`Toggle ${c} Filter`}
@@ -45,7 +44,7 @@ export const FiltersSpells = () => {
       <section class="filter-list">
         {Levels.map((l) => (
           <button
-            class={`pwy-3 pwx-4 bra-1 fld-row flg-3 ai-ctr jc-ctr ${
+            class={`vh-1 pwy-3 pwx-4 bra-1 fld-row flg-3 ai-ctr jc-ctr ${
               isIn(filters.level)(l) ? "ct-primary" : "ct-light"
             }`}
             title={`Toggle ${ordinal(l)} Level Filter`}
@@ -58,7 +57,7 @@ export const FiltersSpells = () => {
       <section class="filter-list">
         {Sources.map((src) => (
           <button
-            class={`pwa-3 bra-1 fld-row ai-ctr jc-ctr ${
+            class={`vh-1 pwa-3 bra-1 fld-row ai-ctr jc-ctr ${
               isIn(filters.source)(src) ? "ct-primary" : "ct-light"
             }`}
             title={`Toggle ${src} Sourcebook Filter`}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,8 +1,12 @@
-import { h } from "preact";
+import { h, FunctionalComponent } from "preact";
 import { FaGithub } from "react-icons/fa";
 
-export const Footer = () => (
-  <footer class="js-end vw-vw100 vhmn-2 fld-row flg-4 ai-ctr jc-ctr ct-light">
+interface FooterProps {
+  className?: string;
+}
+
+export const Footer: FunctionalComponent<FooterProps> = ({ className }) => (
+  <footer class={`${className} vw-vw100 vhmn-2 fld-row flg-4 ai-ctr jc-ctr ct-light`}>
     <span class="fs-u2 mwbr-3">
       <a href="https://github.com/baetheus/spellbook" target="_blank" class="ct-light">
         <FaGithub />

--- a/src/components/Layouts/DefaultLayout.tsx
+++ b/src/components/Layouts/DefaultLayout.tsx
@@ -5,10 +5,10 @@ import { Footer } from "../Footer";
 
 export const DefaultLayout: FunctionalComponent<{}> = ({ children }) => {
   return (
-    <main class="fld-col ai-stc vh-vh100 vw-p100">
+    <main class="vh-vh100 vw-p100 fld-col ai-ctr vwcmx-em1 vwc-p100">
       <Header />
       <section class="fls-1-1 fld-col ai-stc">{children}</section>
-      <Footer />
+      <Footer className="brt-1" />
     </main>
   );
 };

--- a/src/components/SearchSpells/SearchSpells.tsx
+++ b/src/components/SearchSpells/SearchSpells.tsx
@@ -58,7 +58,7 @@ export const SearchSpells = () => {
       {showConfig ? <FiltersSpells /> : null}
       <section class="fld-row flg-3 ai-ctr">
         <button
-          class="ct-light fls-1-1 vh-1 fs-u2 bra-1 fld-row ai-ctr jc-ctr"
+          class="ct-light fls-3-1 vh-1 fs-u2 bra-1 fld-row ai-ctr jc-ctr"
           onClick={handleClearBook}
         >
           Clear Selection

--- a/src/components/SpellCard/SpellCard.scss
+++ b/src/components/SpellCard/SpellCard.scss
@@ -3,13 +3,61 @@
   height: 5.25in;
 }
 
-.line-break-children p {
+.card {
+  display: grid;
+  grid-template:
+    "head head head head" auto
+    "time time rang rang" auto
+    "comp comp dura dura" auto
+    "mats mats mats mats" auto
+    "desc desc desc desc" 1fr
+    "spel spel spel spel" auto / 1fr 1fr 1fr 1fr;
+  gap: var(--margin-width-2);
+}
+
+.card > .head {
+  grid-area: head;
+}
+
+.card > .time {
+  grid-area: time;
+}
+
+.card > .rang {
+  grid-area: rang;
+}
+
+.card > .comp {
+  grid-area: comp;
+}
+
+.card > .dura {
+  grid-area: dura;
+}
+
+.card > .mats {
+  grid-area: mats;
+}
+
+.card > .desc {
+  grid-area: desc;
+}
+
+.card > .spel {
+  grid-area: spel;
+}
+
+.inner-children p {
   margin-bottom: var(--margin-width-4);
 }
 
-.card ul {
-  list-style: inside circle;
+.inner-children ul {
+  list-style: none;
   font-size: var(--font-size-d2);
-  padding-left: var(--margin-width-4);
+  // padding-left: var(--margin-width-4);
   margin-bottom: var(--margin-width-4);
+}
+
+.inner-children li:before {
+  content: "● ";
 }

--- a/src/components/SpellCard/SpellCard.tsx
+++ b/src/components/SpellCard/SpellCard.tsx
@@ -41,46 +41,38 @@ export const SpellCard: FunctionalComponent<SpellCardProps> = ({
     <article
       class={`card ${
         fixed ? "fixed-card fs-d2" : "unfixed-card"
-      } fld-col flg-2 pwx-4 pwt-4 pwb-2 bra-1 ${className} ${theme}`}
+      } pwx-4 pwt-4 pwb-2 bra-1 ${className} ${theme}`}
       onClick={handleClick}
     >
-      <header class="fld-col flg-2 ai-stc">
-        <h2 class="ct-base ta-c brt-1">{spell.name}</h2>
-        <section class="fld-row flg-2 fs-d1">
-          <section class="ct-base flb-p50 ta-c">
-            <h6>Casting Time</h6>
-            <p>{spell.casting_time}</p>
-          </section>
-          <section class="ct-base flb-p50 ta-c">
-            <h6>Range</h6>
-            <p>{spell.range}</p>
-          </section>
-        </section>
-        <section class="fld-row flg-2 fs-d1">
-          <section class="ct-base flb-p50 ta-c">
-            <h6>Components</h6>
-            <p>{toSpellComponents(spell)}</p>
-          </section>
-          <section class="ct-base flb-p50 ta-c">
-            <h6>Duration</h6>
-            <p>{spell.duration}</p>
-          </section>
-        </section>
-      </header>
+      <h2 class="head ct-base ta-c brt-1">{spell.name}</h2>
+      <section class="time ct-base ta-c">
+        <h6>Casting Time</h6>
+        <p>{spell.casting_time}</p>
+      </section>
+      <section class="rang ct-base ta-c">
+        <h6>Range</h6>
+        <p>{spell.range}</p>
+      </section>
+      <section class="comp ct-base ta-c">
+        <h6>Components</h6>
+        <p>{toSpellComponents(spell)}</p>
+      </section>
+      <section class="dura ct-base ta-c">
+        <h6>Duration</h6>
+        <p>{spell.duration}</p>
+      </section>
       {spell.components.materials.length ? (
-        <section class="ta-c fs-d2">
+        <section class="mats ta-c fs-d2">
           {spell.components.materials.map((m) => (
             <p>{m}</p>
           ))}
         </section>
       ) : null}
       <section
-        class={`ct-base vhmn-3 fls-1-1 pwa-3 brb-1 ta-j line-break-children ov-au ${toFontSize(
-          spell
-        )}`}
+        class={`desc ct-base pwa-3 brb-1 inner-children ov-au ${toFontSize(spell)}`}
         dangerouslySetInnerHTML={{ __html: spell.description }}
       ></section>
-      <footer class="fld-row jc-spb fs-d1">
+      <footer class="spel fld-row jc-spb fs-d1">
         <section>{toSpellType(spell)}</section>
         <section class="fld-row flg-2 fs-u1">
           {spell.class.map((c) => (

--- a/src/components/SpellTable/SpellTable.tsx
+++ b/src/components/SpellTable/SpellTable.tsx
@@ -15,7 +15,7 @@ export const SpellTable: FunctionalComponent<SpellTableProps> = ({ spells, book,
     <Fragment>
       <section class="spell-table">
         {spells.length === 0 ? <h3>No Spells To Show!</h3> : null}
-        {spells.slice(0, 50).map((spell) => (
+        {spells.slice(0, 100).map((spell) => (
           <SpellCard
             fixed={false}
             spell={spell}
@@ -24,8 +24,8 @@ export const SpellTable: FunctionalComponent<SpellTableProps> = ({ spells, book,
           ></SpellCard>
         ))}
       </section>
-      {spells.length > 50 ? (
-        <span>There are {spells.length - 50} more spells not shown.</span>
+      {spells.length > 100 ? (
+        <span class="vw-p100 ta-c">There are {spells.length - 100} more spells not shown.</span>
       ) : null}
     </Fragment>
   );

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <title>Spellbook</title>
 
     <link
-      href="https://fonts.googleapis.com/css2?family=Lora:wght@700&family=Open+Sans:wght@300,400&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Lora:wght@700&family=Open+Sans:wght@300;400;600&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" type="text/css" href="./styles.scss" />

--- a/src/libraries/spells.ts
+++ b/src/libraries/spells.ts
@@ -11,7 +11,7 @@ export const toSpellLevel = (level: Level): string => {
 export const toSpellType = (s: Spell): string => {
   const level = toSpellLevel(s.level);
   if (s.level === 0) {
-    return `${level} Cantrip`;
+    return `${level}`;
   }
   return `${level} ${s.school}`;
 };

--- a/src/styles/reset.scss
+++ b/src/styles/reset.scss
@@ -8,6 +8,8 @@ html {
   font-size-adjust: 0.6;
   color: var(--color-fore-base-0);
   background-color: var(--color-back-base-0);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 h1,
@@ -45,7 +47,7 @@ small {
 }
 
 strong {
-  font-weight: 400;
+  font-weight: 600;
 }
 
 button {


### PR DESCRIPTION
* update @nll/css
* increase button height of filter buttons
* max width limit on desktop view
* increase width on clear selection button
* flatten spellcard dom with grid
* increase shown cards count to 100
* remove extra "Cantrip" from spell level combinator
* add antialiasing
* almost completely fix card description li bullets

fixes #4