### PR TITLE
feat: about page and other ui

### DIFF
--- a/src/components/FilterSpells/FilterSpells.tsx
+++ b/src/components/FilterSpells/FilterSpells.tsx
@@ -11,6 +11,7 @@ import {
   Sources,
   Levels,
   Classes,
+  resetFilters,
 } from "~/store";
 import { ClassIcon } from "../SpellCard";
 import { isIn } from "~/libraries/fns";
@@ -19,20 +20,30 @@ import { toSpellLevel } from "~/libraries/spells";
 
 export const FiltersSpells = () => {
   const [filters] = useStore(filtersL.get);
-  const [handleSource, handleClass, handleLevel] = useDispatch(
+  const [handleSource, handleClass, handleLevel, handleReset] = useDispatch(
     toggleSource,
     toggleClass,
-    toggleLevel
+    toggleLevel,
+    resetFilters
   );
 
   return (
-    <section class="fld-col flg-3 ai-end">
+    <section class="fld-col flg-3 ai-stc">
+      <button
+        class="vh-1 pwy-3 pwx-4 bra-1 fld-row flg-3 ai-ctr jc-ctr ct-primary"
+        label="Show Everything"
+        title="Show Everything"
+        onClick={handleReset}
+      >
+        Show Everything
+      </button>
       <section class="filter-list">
         {Classes.map((c) => (
           <button
             class={`vh-1 pwa-3 bra-1 fld-row flg-3 ai-ctr jc-ctr ${
               isIn(filters.class)(c) ? "ct-primary" : "ct-light"
             }`}
+            label={`Toggle ${c} Filter`}
             title={`Toggle ${c} Filter`}
             onClick={() => handleClass(c)}
           >
@@ -47,6 +58,7 @@ export const FiltersSpells = () => {
             class={`vh-1 pwy-3 pwx-4 bra-1 fld-row flg-3 ai-ctr jc-ctr ${
               isIn(filters.level)(l) ? "ct-primary" : "ct-light"
             }`}
+            label={`Toggle ${ordinal(l)} Level Filter`}
             title={`Toggle ${ordinal(l)} Level Filter`}
             onClick={() => handleLevel(l)}
           >
@@ -60,6 +72,7 @@ export const FiltersSpells = () => {
             class={`vh-1 pwa-3 bra-1 fld-row ai-ctr jc-ctr ${
               isIn(filters.source)(src) ? "ct-primary" : "ct-light"
             }`}
+            label={`Toggle ${src} Sourcebook Filter`}
             title={`Toggle ${src} Sourcebook Filter`}
             onClick={() => handleSource(src)}
           >

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,14 +7,24 @@ interface FooterProps {
 
 export const Footer: FunctionalComponent<FooterProps> = ({ className }) => (
   <footer class={`${className} vw-vw100 vhmn-2 fld-row flg-4 ai-ctr jc-ctr ct-light`}>
-    <span class="fs-u2 mwbr-3">
-      <a href="https://github.com/baetheus/spellbook" target="_blank" class="ct-light">
+    <span class="fs-u2 trns-d2">
+      <a
+        href="https://github.com/baetheus/spellbook"
+        target="_blank"
+        title="Link to source code on github"
+        class="ct-light"
+      >
         <FaGithub />
       </a>
     </span>
     <span>
       Designed by{" "}
-      <a href="https://blaylock.dev" target="_blank" class="ct-light cf-link">
+      <a
+        href="https://blaylock.dev"
+        target="_blank"
+        title="Link to Brandon Blaylock's personal website"
+        class="ct-light cf-link"
+      >
         Brandon Blaylock
       </a>
     </span>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,16 +1,18 @@
 import { h } from "preact";
 import { Link } from "preact-router";
 
+import { MdHelp } from "react-icons/md";
+
 export const Header = () => (
-  <header class="fld-row flg-4 ai-ctr jc-ctr vhmn-3 mwx-4 ovx-au">
-    <h2>
+  <header class="fld-row flg-4 ai-ctr jc-spb vhmn-3 ovx-au pwr-5">
+    <h1>
       <Link href="/" class="pwx-3 bra-1">
         Spellbook
       </Link>
-    </h2>
+    </h1>
     <nav class="fld-row flg-3 ai-ctr">
-      <Link href="/" activeClassName="ct-link-reverse" class="pwx-3 bra-1">
-        About
+      <Link href="/about" activeClassName="ct-link-reverse" class="bra-1 fs-u3 trns-d3">
+        <MdHelp />
       </Link>
     </nav>
   </header>

--- a/src/components/Layouts/DefaultLayout.tsx
+++ b/src/components/Layouts/DefaultLayout.tsx
@@ -5,9 +5,9 @@ import { Footer } from "../Footer";
 
 export const DefaultLayout: FunctionalComponent<{}> = ({ children }) => {
   return (
-    <main class="vh-vh100 vw-p100 fld-col ai-ctr vwcmx-em1 vwc-p100">
+    <main class="vh-vh100 vw-p100 fld-col ai-ctr vwcmx-em1 vwc-p100 pwx-4 ova-vi">
       <Header />
-      <section class="fls-1-1 fld-col ai-stc">{children}</section>
+      <section class="fls-1-1 fld-col flg-4 ai-stc">{children}</section>
       <Footer className="brt-1" />
     </main>
   );

--- a/src/components/SearchSpells/SearchSpells.tsx
+++ b/src/components/SearchSpells/SearchSpells.tsx
@@ -31,12 +31,13 @@ export const SearchSpells = () => {
         <input
           value={phrase}
           onInput={handleInput}
-          label="Search"
+          label="Filter spells by search string"
           placeholder="Search"
           class="vh-2 fls-1-1 ct-light brl-1 pwx-5 bwa-0 fs-u1"
         />
         <button
           type="button"
+          label="Clear search string"
           class={`search-button fs-u4 fld-row ai-ctr jc-ctr ct-light ${
             phrase.length === 0 ? "cf-disabled" : ""
           }`}
@@ -47,6 +48,7 @@ export const SearchSpells = () => {
         </button>
         <button
           type="button"
+          label={`${showConfig ? "Hide" : "Show"} settings menu`}
           class={`search-button fs-u4 fld-row ai-ctr jc-ctr  brr-1 ${
             showConfig ? "ct-primary" : "ct-light"
           }`}
@@ -58,13 +60,15 @@ export const SearchSpells = () => {
       {showConfig ? <FiltersSpells /> : null}
       <section class="fld-row flg-3 ai-ctr">
         <button
-          class="ct-light fls-3-1 vh-1 fs-u2 bra-1 fld-row ai-ctr jc-ctr"
+          label="Clear selected spells"
+          class="ct-light fls-3-1 vh-1 fs-u1 bra-1 fld-row ai-ctr jc-ctr"
           onClick={handleClearBook}
         >
-          Clear Selection
+          Clear Selections
         </button>
         <button
-          class="ct-primary fls-1-1 vh-1 fs-u2 bra-1 fld-row ai-ctr jc-ctr"
+          label="Go to print spells page"
+          class="ct-primary fls-1-1 vh-1 fs-u1 bra-1 fld-row ai-ctr jc-ctr"
           onClick={() => route("/print")}
         >
           Print

--- a/src/components/SpellCard/SpellCard.tsx
+++ b/src/components/SpellCard/SpellCard.tsx
@@ -37,12 +37,25 @@ export const SpellCard: FunctionalComponent<SpellCardProps> = ({
   onClick = () => {},
 }) => {
   const handleClick = useCallback(() => onClick(spell), [spell, onClick]);
+  const handleKeyUp = useCallback<h.JSX.KeyboardEventHandler<any>>(
+    (e) => {
+      if (e.code === "Enter" || e.code === "Space") {
+        e.preventDefault();
+        onClick(spell);
+      }
+    },
+    [spell, onClick]
+  );
+
   return (
     <article
+      tabIndex={0}
+      label={`${spell.name} spell card - ${theme === "ct-dark" ? "Unselected" : "Selected"}`}
       class={`card ${
         fixed ? "fixed-card fs-d2" : "unfixed-card"
       } pwx-4 pwt-4 pwb-2 bra-1 ${className} ${theme}`}
       onClick={handleClick}
+      onKeyPress={handleKeyUp}
     >
       <h2 class="head ct-base ta-c brt-1">{spell.name}</h2>
       <section class="time ct-base ta-c">

--- a/src/components/SpellTable/SpellTable.tsx
+++ b/src/components/SpellTable/SpellTable.tsx
@@ -13,8 +13,8 @@ interface SpellTableProps {
 export const SpellTable: FunctionalComponent<SpellTableProps> = ({ spells, book, toggleSpell }) => {
   return (
     <Fragment>
+      {spells.length === 0 ? <h3 class="as-ctr js-ctr ta-c">No Spells To Show!</h3> : null}
       <section class="spell-table">
-        {spells.length === 0 ? <h3>No Spells To Show!</h3> : null}
         {spells.slice(0, 100).map((spell) => (
           <SpellCard
             fixed={false}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import { Router } from "preact-router";
 import { PrintPage } from "./pages/PrintPage";
 import { BrowsePage } from "./pages/BrowsePage";
 import { NotFoundPage } from "./pages/NotFoundPage";
+import { AboutPage } from "./pages/AboutPage/AboutPage";
 
 /**
  * Run App
@@ -15,6 +16,7 @@ const App = () => (
   <Router>
     <BrowsePage path="/" />
     <PrintPage path="/print" />
+    <AboutPage path="/about" />
     <NotFoundPage default />
   </Router>
 );

--- a/src/pages/AboutPage/AboutPage.scss
+++ b/src/pages/AboutPage/AboutPage.scss
@@ -1,0 +1,6 @@
+.about-content > ul.about-list {
+  list-style: inside circle;
+  margin-left: 0 !important;
+  padding-left: 32px !important;
+  text-indent: -23px;
+}

--- a/src/pages/AboutPage/AboutPage.tsx
+++ b/src/pages/AboutPage/AboutPage.tsx
@@ -1,0 +1,101 @@
+import "./AboutPage.scss";
+
+import { h, FunctionalComponent } from "preact";
+import { Link } from "preact-router";
+
+import { DefaultLayout } from "~/components/Layouts";
+
+export const AboutPage: FunctionalComponent<{}> = () => {
+  return (
+    <DefaultLayout>
+      <article class="about-content fld-col flg-5 mwb-6">
+        <h2>Usage</h2>
+        <p>
+          The <Link href="/">Search</Link> page is useful for both browsing spells and building a
+          spellbook.
+        </p>
+        <p>
+          <strong>Browsing.</strong> If it's your first time to the site, finding a spell is a
+          simple as typing part of its name into the search box. The spell list will filter to only
+          show spells that include your search term in the spell name. If you've already used the
+          filters to hide some spells, you may need to remove some filters to find your spell. To
+          this end there is a "Show Everything" button in the filters list that will disable all
+          filters.
+        </p>
+        <p>
+          <strong>Selecting.</strong> To select a spell to add to your spell list you can click
+          anywhere on the spellcard you want. If the spell card border is blue, then that spell is
+          in your printable spell list, if it is black, then it is not. To unselect the spell,
+          simply click the spell card again. Selected spells will not be filtered out of the shown
+          list, so you can select your cantrips, then filter cantrips out to start selecting your
+          first level spells, etc. To clear your selections, there is a <em>Clear Selections</em>{" "}
+          button above the spell list that will do so.
+        </p>
+        <p>
+          <strong>Printing.</strong> Once you've selected the spells you wish to print, you can
+          click the print button right below the search bar. Doing so will navigate you to a page
+          that is printable on A4 paper in portrait orientation.
+        </p>
+        <p>
+          <strong>Filtering.</strong> To the right of the search box is an icon shaped like a gear.
+          Clicking this will show all of the available filters for spellbook, clicking it again will
+          hide the filters. If a filter button is blue, then spells that match that filter will show
+          up in the list. There are filters for <em>Class</em>, <em>Spell Level</em>, and{" "}
+          <em>Source Book</em>. Within the source book filters <strong>PHB</strong> stands for{" "}
+          <a
+            href="https://dnd.wizards.com/products/tabletop-games/rpg-products/rpg_playershandbook"
+            target="_blank"
+          >
+            Player's Handbook
+          </a>
+          , <strong>XAN</strong> stands for{" "}
+          <a
+            href="https://dnd.wizards.com/products/tabletop-games/rpg-products/xanathars-guide-everything"
+            target="_blank"
+          >
+            Xanathar's Guide to Everything
+          </a>
+          , and <strong>WLD</strong> stands for{" "}
+          <a href="https://dnd.wizards.com/products/wildemount" target="_blank">
+            Explorer's Guide to Wildemount
+          </a>
+          .
+        </p>
+
+        <h2>History</h2>
+        <p>
+          <Link href="/">Spellbook</Link> started as a weekend project to provide a more complete
+          spell list with a better ui than{" "}
+          <a href="https://colinmarc.com/dndspells/" target="_blank">
+            this site by Colin Marc
+          </a>
+          . The specific goals were to make a mobile friendly D&D5e spellbook that is quick enough
+          to use during a session, to make building a spell list for your character easy, and to
+          provide printable spell cards that contain the full text of the spell (without having two
+          cards for some spells). In addition to the technical goals, I also wanted to make a site
+          that had no ads, tracking, or other nonsense. I think this project has achieved these
+          goals.
+        </p>
+        <p>
+          Given the raison d'etre, that doesn't mean that the project is going to languish without
+          improvement. In particular, I have the following stretch goals:
+        </p>
+        <ul class="about-list">
+          <li>The ability to add homebrew spell cards that are printable and shareable.</li>
+          <li>Shareable links to premade spell books.</li>
+          <li>
+            Useful pdfs: Character Sheets, Hex Maps, Name Sheets, Session Note Templates, and Hint
+            Sheets.
+          </li>
+          <li>Additional compendiums for weapons, monsters, etc.</li>
+          <li>Shared dice rollers.</li>
+        </ul>
+        <p>
+          That said, if you find any bugs, spelling errors, or have other issues feel free to file a
+          bug on the site github or to contact me at{" "}
+          <a href="mailto:brandon@ignoble.dev">brandon@ignoble.dev</a>.
+        </p>
+      </article>
+    </DefaultLayout>
+  );
+};

--- a/src/pages/BrowsePage/BrowsePage.tsx
+++ b/src/pages/BrowsePage/BrowsePage.tsx
@@ -11,10 +11,8 @@ export const BrowsePage: FunctionalComponent<{}> = () => {
 
   return (
     <DefaultLayout>
-      <section class="fld-col flg-4 pwa-4">
-        <SearchSpells />
-        <SpellTable spells={spells} book={book} toggleSpell={handleToggle} />
-      </section>
+      <SearchSpells />
+      <SpellTable spells={spells} book={book} toggleSpell={handleToggle} />
     </DefaultLayout>
   );
 };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -4,3 +4,59 @@
 @import "./styles/reset.scss";
 // Nll Styles
 @import "./styles/nll.scss";
+
+.trns-d1 {
+  transform: translateY(var(--margin-width-1));
+}
+
+.trns-d2 {
+  transform: translateY(var(--margin-width-2));
+}
+
+.trns-d3 {
+  transform: translateY(var(--margin-width-3));
+}
+
+.trns-d4 {
+  transform: translateY(var(--margin-width-4));
+}
+
+.trns-d5 {
+  transform: translateY(var(--margin-width-5));
+}
+
+.trns-d6 {
+  transform: translateY(var(--margin-width-6));
+}
+
+.trns-d7 {
+  transform: translateY(var(--margin-width-7));
+}
+
+.trns-u1 {
+  transform: translateY(calc(-1 * var(--margin-width-1)));
+}
+
+.trns-u2 {
+  transform: translateY(calc(-1 * var(--margin-width-2)));
+}
+
+.trns-u3 {
+  transform: translateY(calc(-1 * var(--margin-width-3)));
+}
+
+.trns-u4 {
+  transform: translateY(calc(-1 * var(--margin-width-4)));
+}
+
+.trns-u5 {
+  transform: translateY(calc(-1 * var(--margin-width-5)));
+}
+
+.trns-u6 {
+  transform: translateY(calc(-1 * var(--margin-width-6)));
+}
+
+.trns-u7 {
+  transform: translateY(calc(-1 * var(--margin-width-7)));
+}


### PR DESCRIPTION
* create initial about page
* add reset filters button to filters panel
* cleanup icons in header and footer
* hoist spacing in defaultlayout
* add accessibility labels to all buttons
* make spell cards focusable and handle enter and space for select
events
* hoist No Spells To Show! line out of grid so it is centered
* remove wrapper element on browse page (because of layout hoist)

fixed #5